### PR TITLE
Handle code refs in stashes

### DIFF
--- a/lib/Attribute/Contract.pm
+++ b/lib/Attribute/Contract.pm
@@ -154,13 +154,17 @@ sub findsym {
     my $type = ref($ref);
 
     no strict 'refs';
-    foreach my $sym (values %{$package . "::"}) {
+    my $symtab = \%{$package . "::"};
+    foreach (keys %$symtab) { foreach my $sym ( $$symtab{$_} ) {
+        if (ref $sym && $sym == $ref) {
+            return $symcache{$package, $ref} = \*{"$package:\:$_"};
+        }
         use strict;
         next unless ref(\$sym) eq 'GLOB';
 
         return $symcache{$package, $ref} = \$sym
           if *{$sym}{$type} && *{$sym}{$type} == $ref;
-    }
+    }}
 
     return;
 }


### PR DESCRIPTION
From the perldelta for 5.27.6:

> =head2 Subroutines no longer need typeglobs
> 
> Perl 5.22.0 introduced an optimization allowing subroutines to be stored in
> packages as simple sub refs, not requiring a full typeglob (thus
> potentially saving large amounts of memeory).  However, the optimization
> was flawed: it only applied to the main package.
> 
> This optimization has now been extended to all packages.  This may break
> compatibility with introspection code that looks inside stashes and expects
> everything in them to be a typeglob.
> 
> When this optimization happens, the typeglob still notionally exists, so
> accessing it will cause the stash entry to be upgraded to a typeglob.  The
> optimization does not apply to XSUBs or exported subroutines, and calling a
> method will undo it, since method calls cache things in typeglobs.
> 
> [perl #129916] [perl #132252]
